### PR TITLE
explicit cast to Data for pointer arguments

### DIFF
--- a/LibraryC/Tests/list.cpp
+++ b/LibraryC/Tests/list.cpp
@@ -16,9 +16,9 @@ int main()
         return 1;
     }
 
-    list_insert(list, new int(1));
-    list_insert(list, new int(2));
-    list_insert(list, new int(3));
+    list_insert(list, (Data)new int(1));
+    list_insert(list, (Data)new int(2));
+    list_insert(list, (Data)new int(3));
 
     ListItem *item = list_first(list);
     if (!item)
@@ -50,7 +50,7 @@ int main()
         return 1;
     }
 
-    list_insert_after(list, list_first(list), new int(4));
+    list_insert_after(list, list_first(list), (Data)new int(4));
 
     item = list_item_next(list_first(list));
     if (!item)

--- a/LibraryC/Tests/stack.cpp
+++ b/LibraryC/Tests/stack.cpp
@@ -8,7 +8,7 @@ void myfree(void *p)
 
 int stack_get_int(Stack *s)
 {
-    void *v = stack_get(s);
+    void *v = (void*)stack_get(s);
     if (!v)
     {
         std::cout << "Invalid stack_get\n";
@@ -22,9 +22,9 @@ int main()
 {
     Stack *stack = stack_create(myfree);
 
-    stack_push(stack, new int(1));
-    stack_push(stack, new int(2));
-    stack_push(stack, new int(3));
+    stack_push(stack, (Data)new int(1));
+    stack_push(stack, (Data)new int(2));
+    stack_push(stack, (Data)new int(3));
 
     if (stack_get_int(stack) != 3)
     {
@@ -54,8 +54,8 @@ int main()
     }
 
     std::cout << "Get: " << stack_get_int(stack) << "\n";
-    stack_push(stack, new int(4));
-    stack_push(stack, new int(5));
+    stack_push(stack, (Data)new int(4));
+    stack_push(stack, (Data)new int(5));
 
     if (stack_get_int(stack) != 5)
     {


### PR DESCRIPTION
Добавил явное приведение типов как заставляет С++ в LibraryC/Tests/list.cpp и LibraryC/Tests/stack.cpp
ошибка была такая  - error: invalid conversion from 'int*' to 'Data' {aka 'long long unsigned int'}
я честно говоря не хочу менять у себя в коде тип Data с uintptr_t на void* и потом каждый раз приводить у себя в (Data)(uintptr_t).
 В тесте array.cpp это есть, почему тут нет я не понял, возможно был какой-то смысл, но я его не понял :)